### PR TITLE
Fix bugs if only one process owns the global data.

### DIFF
--- a/scalapy/core.py
+++ b/scalapy/core.py
@@ -518,13 +518,22 @@ class DistributedMatrix(object):
         -------
         dm : DistributedMatrix
         """
-        if mat.ndim != 2:
-            raise ScalapyException("Array must be 2d.")
-
         # Broadcast if rank is not set.
         if rank is not None:
             comm = context.mpi_comm if context else _context.mpi_comm
+
+            # Double check that rank is valid.
+            if rank < 0 or rank >= comm.size:
+                raise ScalapyException("Invalid rank.")
+
+            if comm.rank == rank:
+                if mat.ndim != 2:
+                    raise ScalapyException("Array must be 2d.")
+
             mat = comm.bcast(mat, root=rank)
+        else:
+            if mat.ndim != 2:
+                raise ScalapyException("Array must be 2d.")
 
         m = cls(mat.shape, block_shape=block_shape, dtype=mat.dtype.type, context=context)
 


### PR DESCRIPTION
Now it works for the following case:

``` python
# matrix size
ns = 5

if rank == 0:
    A = np.random.standard_normal((ns, ns)).astype(np.float64)
else:
    A = None

dA = core.DistributedMatrix.from_global_array(A, rank=0)
```
