### PR TITLE
Python 3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,13 @@ created whilst hiding all the nasty details of block cyclic distribution.
 Dependencies
 ============
 
-This package depends upon two python packages ``numpy`` and ``mpi4py``. It is
-written largely in pure Python, but some parts require ``Cython`` and
-``f2py``. Obviously it also requires an ``MPI`` distribution (OpenMPI and
-IntelMPI supported out the box), and a ``Scalapack`` installation (both Intel
-MKL and NETLIB are currently supported).
+``scalapy`` supports both Python 2 and 3 (2.7, 3.2 or later).
+
+The package depends upon two python packages ``numpy`` and ``mpi4py``. It is
+written largely in pure Python, but some parts require ``Cython`` and ``f2py``.
+It also requires an ``MPI`` distribution (OpenMPI and IntelMPI supported out the
+box), and a ``Scalapack`` installation (both Intel MKL and NETLIB are currently
+supported).
 
 Installation
 ============
@@ -37,11 +39,11 @@ Limited, but improving, documentation is available `here <http://jrs65.github.co
 MPI Version (OpenMPI 1.8.2 or higher)
 =====================================
 
-Some of the features, especially distribution of matrice from global arrays
-and files, make heavy use of advanced features of MPI, such as derived
-datatypes and MPI-IO. Unfortunately many MPI distributions contain critical
-bugs in these components (mostly due to ``ROMIO``), which means these will
-fail in some common circumstances.
+Some of the features, especially distribution of matrices from global arrays and
+files, make heavy use of advanced features of MPI, such as derived datatypes and
+MPI-IO. Unfortunately many MPI distributions contain critical bugs in these
+components (mostly due to ``ROMIO``), which means these will fail in some common
+circumstances.
 
 However, recent versions of OpenMPI contain a new implementation of MPI-IO
 (called OMPIO) which seems to be issue free. This means that for full, and
@@ -54,7 +56,3 @@ can be done by calling with::
 or by setting the environment variable::
 
     $ export OMPI_MCA_io=ompio
-
-
-
- 

--- a/bin/benchmark.py
+++ b/bin/benchmark.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import scalapy
 import numpy as np
@@ -45,20 +46,20 @@ A = scalapy.DistributedMatrix([n, n])
 
 
 if rank == 0:
-    print "==============================================="
-    print "Decomposing  %i x %i global matrix" % (n, n)
-    print
-    print "Local shape: %i x %i" % A.local_shape
-    print "Blocksize:   %i x %i" % (B, B)
-    print "Pgrid size:  %i x %i" % (npx, npy)
-    print
-    print "Number of threads: %i" % (int(os.environ['OMP_NUM_THREADS']) if 'OMP_NUM_THREADS' in os.environ else 0)
-    print "==============================================="
-    print
+    print("===============================================")
+    print("Decomposing  %i x %i global matrix" % (n, n))
+    print()
+    print("Local shape: %i x %i" % A.local_shape)
+    print("Blocksize:   %i x %i" % (B, B))
+    print("Pgrid size:  %i x %i" % (npx, npy))
+    print()
+    print("Number of threads: %i" % (int(os.environ['OMP_NUM_THREADS']) if 'OMP_NUM_THREADS' in os.environ else 0))
+    print("===============================================")
+    print()
 
 
 if comm.Get_rank() == 0:
-    print "Setting up..."
+    print("Setting up...")
     st = time.time()
 
 
@@ -76,9 +77,9 @@ comm.Barrier()
 
 if comm.Get_rank() == 0:
     et = time.time()
-    print "Done. Time: ", et-st
+    print("Done. Time: ", et-st)
     st = time.time()
-    print "Starting eigenvalue solve..."
+    print("Starting eigenvalue solve...")
 
 evals1, evecs1 = scalapy.eigh(A, overwrite_a=False)
 
@@ -86,7 +87,7 @@ comm.Barrier()
 
 if comm.Get_rank() == 0:
     et = time.time()
-    print "Done. Time: ", et-st
+    print("Done. Time: ", et-st)
 
     evtime = et - st
 
@@ -94,7 +95,7 @@ comm.Barrier()
 
 if comm.Get_rank() == 0:
     st = time.time()
-    print "Starting Cholesky..."
+    print("Starting Cholesky...")
 
 U = scalapy.cholesky(A, overwrite_a=False)
 
@@ -102,12 +103,12 @@ comm.Barrier()
 
 if comm.Get_rank() == 0:
     et = time.time()
-    print "Done. Time: ", et-st
+    print("Done. Time: ", et-st)
 
     chtime = et - st
 
     st = time.time()
-    print "Starting matrix multiply..."
+    print("Starting matrix multiply...")
 
 
 A2 = scalapy.dot(U, U, transA='T')
@@ -117,12 +118,12 @@ comm.Barrier()
 
 if comm.Get_rank() == 0:
     et = time.time()
-    print "Done. Time: ", et-st
+    print("Done. Time: ", et-st)
 
     mltime = et - st
 
     st = time.time()
-    print "Starting verification..."
+    print("Starting verification...")
 
 
 # Calculate eigenvalues by fourier transform.
@@ -132,9 +133,9 @@ evals2 = np.sort(np.fft.fft(f(px)).real)
 
 
 if comm.Get_rank() == 0:
-    print "Max diff:", np.abs((evals1 - evals2) / evals1).max()
+    print("Max diff:", np.abs((evals1 - evals2) / evals1).max())
 
-    print "Max diff A, rnk 0:", np.abs(A.local_array - A2.local_array).max() / np.abs(A.local_array).max()
+    print("Max diff A, rnk 0:", np.abs(A.local_array - A2.local_array).max() / np.abs(A.local_array).max())
 
     #bfile = bfile + "_%i_%i_%i_%i_%i.dat" % (n, B, npx, npy, nthread)
 

--- a/bin/benchmark.py
+++ b/bin/benchmark.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, division, absolute_import
 
 import scalapy
 import numpy as np
@@ -142,5 +142,3 @@ if comm.Get_rank() == 0:
     with open(bfile, "w+") as f:
         line = "%i %i %i %i %i %g %g %g\n" % (n, B, npx, npy, nthread, evtime, chtime, mltime)
         f.write(line)
-
-

--- a/bin/benchmark_single.py
+++ b/bin/benchmark_single.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
@@ -28,8 +28,8 @@ print("Decomposing  %i x %i global matrix" % (n, n))
 print()
 print("Number of threads: %i" % (int(os.environ['OMP_NUM_THREADS']) if 'OMP_NUM_THREADS' in os.environ else 0))
 print("===============================================")
-print() 
-    
+print()
+
 st = time.time()
 # Construct array of distances between indices (taking into account
 # periodicity).
@@ -75,7 +75,7 @@ print("Done. Time: ", et-st)
 chtime = et - st
 
 #================
-    
+
 st = time.time()
 print("Starting matrix multiply...")
 
@@ -86,11 +86,11 @@ print("Done. Time: ", et-st)
 mltime = et - st
 
 #================
-    
+
 st = time.time()
 print("Starting verification...")
 
-    
+
 # Calculate eigenvalues by fourier transform.
 x = np.arange(n, dtype=np.float64)
 px = np.where(x < n-x, x, n-x)
@@ -106,5 +106,3 @@ print("A == A2:", me)
 #bfile = bfile + "_%i_%i_%i_%i_%i.dat" % (n, B, npx, npy, nthread)
 
 print("%i %i %g %g %g\n" % (n, nthread, evtime, chtime, mltime))
-
-

--- a/bin/benchmark_single.py
+++ b/bin/benchmark_single.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import numpy as np
 
@@ -22,12 +23,12 @@ nthread = int(sys.argv[2])
 os.environ['OMP_NUM_THREADS'] = repr(nthread)
 
 
-print "==============================================="
-print "Decomposing  %i x %i global matrix" % (n, n)
-print
-print "Number of threads: %i" % (int(os.environ['OMP_NUM_THREADS']) if 'OMP_NUM_THREADS' in os.environ else 0)
-print "==============================================="
-print 
+print("===============================================")
+print("Decomposing  %i x %i global matrix" % (n, n))
+print()
+print("Number of threads: %i" % (int(os.environ['OMP_NUM_THREADS']) if 'OMP_NUM_THREADS' in os.environ else 0))
+print("===============================================")
+print() 
     
 st = time.time()
 # Construct array of distances between indices (taking into account
@@ -50,14 +51,14 @@ del da
 #================
 
 et = time.time()
-print "Done. Time: ", et-st
+print("Done. Time: ", et-st)
 st = time.time()
-print "Starting eigenvalue solve..."
+print("Starting eigenvalue solve...")
 
 evals1, evecs1 = la.eigh(A)
 
 et = time.time()
-print "Done. Time: ", et-st
+print("Done. Time: ", et-st)
 del evecs1
 
 evtime = et - st
@@ -65,29 +66,29 @@ evtime = et - st
 #================
 
 st = time.time()
-print "Starting Cholesky..."
+print("Starting Cholesky...")
 
 U = la.cholesky(A)
 
 et = time.time()
-print "Done. Time: ", et-st
+print("Done. Time: ", et-st)
 chtime = et - st
 
 #================
     
 st = time.time()
-print "Starting matrix multiply..."
+print("Starting matrix multiply...")
 
 A2 = np.dot(U.T, U)
 
 et = time.time()
-print "Done. Time: ", et-st
+print("Done. Time: ", et-st)
 mltime = et - st
 
 #================
     
 st = time.time()
-print "Starting verification..."
+print("Starting verification...")
 
     
 # Calculate eigenvalues by fourier transform.
@@ -97,13 +98,13 @@ evals2 = np.sort(np.fft.fft(f(px)).real)
 
 me = (A==A2).all()
 
-print "Max diff:", np.abs((evals1 - evals2) / evals1).max()
+print("Max diff:", np.abs((evals1 - evals2) / evals1).max())
 
-print "A == A2:", me
+print("A == A2:", me)
 #print "Max diff A, rnk 0:", np.abs(A - A2.local_matrix).max() / np.abs(A.local_matrix).max()
 
 #bfile = bfile + "_%i_%i_%i_%i_%i.dat" % (n, B, npx, npy, nthread)
 
-print "%i %i %g %g %g\n" % (n, nthread, evtime, chtime, mltime)
+print("%i %i %g %g %g\n" % (n, nthread, evtime, chtime, mltime))
 
 

--- a/bin/cbench/mkjobscript.py
+++ b/bin/cbench/mkjobscript.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import sys
 import os
@@ -22,7 +23,7 @@ pernode = 1
 
 timingest = 12*int(5.0 * ((25.0 * 8) / (pside**2 * nthread)) * (gsize**3 / 5e4**3)) + 1
 
-print "Timing estimate: %i minutes, requesting %i minutes" % (timingest, 2*timingest+5)
+print("Timing estimate: %i minutes, requesting %i minutes" % (timingest, 2*timingest+5))
 
 script="""
 #!/bin/bash

--- a/bin/mkjobscript.py
+++ b/bin/mkjobscript.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import
 
 import sys
 import os

--- a/bin/mpi-io-2.py
+++ b/bin/mpi-io-2.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+from __future__ import print_function, division, absolute_import
+
 from pyscalapack import blockcyclic
 
 import numpy as np
@@ -23,9 +24,9 @@ if rank == 0:
 
     arrf = np.asfortranarray(arrc)
     arrf.T.tofile("testarr_f.dat")
-    
+
     print(arrc)
-    
+
     print(arrf)
 
 
@@ -36,10 +37,10 @@ local_array_f = blockcyclic.mpi_readmatrix("testarr_f.dat", comm, gshape,
                                            np.float64, blocksize, pshape, order='F')
 
 for i in range(size):
-    comm.Barrier() 
+    comm.Barrier()
 
     if rank == i:
-        print([int(rank / pshape[1]), int(rank % pshape[1])])
+        print([int(rank // pshape[1]), int(rank % pshape[1])])
         #print local_array.flags
         #print local_array
 
@@ -74,6 +75,3 @@ if rank == 0:
 
 
 MPI.Finalize()
-
-
-

--- a/bin/mpi-io-2.py
+++ b/bin/mpi-io-2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from pyscalapack import blockcyclic
 
 import numpy as np
@@ -23,9 +24,9 @@ if rank == 0:
     arrf = np.asfortranarray(arrc)
     arrf.T.tofile("testarr_f.dat")
     
-    print arrc
+    print(arrc)
     
-    print arrf
+    print(arrf)
 
 
 
@@ -38,16 +39,16 @@ for i in range(size):
     comm.Barrier() 
 
     if rank == i:
-        print [int(rank / pshape[1]), int(rank % pshape[1])]
+        print([int(rank / pshape[1]), int(rank % pshape[1])])
         #print local_array.flags
         #print local_array
 
-        print "Fortran ordered."
-        print local_array_f
-        print
-        print "C ordered."
-        print local_array_c
-        print
+        print("Fortran ordered.")
+        print(local_array_f)
+        print()
+        print("C ordered.")
+        print(local_array_c)
+        print()
 
 blockcyclic.mpi_writematrix("testarr2_c.dat", local_array_c, comm, gshape,
                             np.float64, blocksize, pshape, order='C')
@@ -63,13 +64,13 @@ if rank == 0:
     arr1_f = np.fromfile("testarr_f.dat")
     arr2_f = np.fromfile("testarr2_f.dat")
 
-    print "F ordered"
-    print arr1_f
-    print arr2_f
-    print
-    print "C ordered"
-    print arr1_c
-    print arr2_c
+    print("F ordered")
+    print(arr1_f)
+    print(arr2_f)
+    print()
+    print("C ordered")
+    print(arr1_c)
+    print(arr2_c)
 
 
 MPI.Finalize()

--- a/bin/mpicontexttest.py
+++ b/bin/mpicontexttest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 from mpi4py import MPI
 import numpy as np
@@ -51,7 +52,7 @@ for i in range(world_comm.size):
     world_comm.Barrier()
 
     if rank == i:
-        print "Group %i. Group rank %i. Rank %i. " % (group_index, group_rank, rank)
-        print evals[-10:]
-        print
+        print("Group %i. Group rank %i. Rank %i. " % (group_index, group_rank, rank))
+        print(evals[-10:])
+        print()
         

--- a/bin/mpicontexttest.py
+++ b/bin/mpicontexttest.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, division, absolute_import
 
 from mpi4py import MPI
 import numpy as np
@@ -18,7 +18,7 @@ world_comm = MPI.COMM_WORLD
 rank = world_comm.rank
 
 # Split the world_group into subgroups of four processes
-group_index = rank / 4
+group_index = rank // 4
 group_rank = rank % 4
 group_indices = np.arange(4) + group_index*4
 new_group = world_group.Incl(group_indices)
@@ -55,4 +55,3 @@ for i in range(world_comm.size):
         print("Group %i. Group rank %i. Rank %i. " % (group_index, group_rank, rank))
         print(evals[-10:])
         print()
-        

--- a/scalapy/__init__.py
+++ b/scalapy/__init__.py
@@ -7,7 +7,7 @@ scalapy (:mod:`scalapy`)
 
 Scalapy is a python package for performing distributed linear algebra using ScaLAPACK.
 """
-from __future__ import absolute_import
+from __future__ import print_function, division
 
 from .core import *
 from .routines import *

--- a/scalapy/__init__.py
+++ b/scalapy/__init__.py
@@ -7,6 +7,7 @@ scalapy (:mod:`scalapy`)
 
 Scalapy is a python package for performing distributed linear algebra using ScaLAPACK.
 """
+from __future__ import absolute_import
 
-from core import *
-from routines import *
+from .core import *
+from .routines import *

--- a/scalapy/blacs.pyx
+++ b/scalapy/blacs.pyx
@@ -44,7 +44,7 @@ def gridinfo(ctxt):
 
     Raises
     ------
-    BLACSException 
+    BLACSException
         If process grid undefined.
     """
     cdef int ictxt, nrows, ncols, row, col
@@ -79,7 +79,10 @@ def gridinit(ctxt, nrows, ncols, order="Row"):
 
     ictxt = <int>ctxt
 
-    if order != "Row":
+    # Ensure order is property converted to an ASCII string
+    order = bytes(order.encode('ascii')) if isinstance(order, str) else order
+
+    if order != b"Row":
         raise Exception("Order not valid.")
 
     # Initialise the grid
@@ -95,4 +98,3 @@ def gridinit(ctxt, nrows, ncols, order="Row"):
     ctxt = ictxt
 
     return ctxt
-

--- a/scalapy/blockcyclic.py
+++ b/scalapy/blockcyclic.py
@@ -21,6 +21,7 @@ Routines
     num_c_lblocks 
     partial_last_block
 """
+from __future__ import print_function
 
 import numpy as np
 
@@ -406,7 +407,7 @@ def mpi_writematrix(fname, local_array, comm, gshape, dtype,
     # Length of filename required for write (in bytes).
     filelength = displacement + gshape[0]*gshape[1]
 
-    print filelength, darr.Get_size()
+    print(filelength, darr.Get_size())
 
     # Open the file, and read out the segments
     f = MPI.File.Open(comm, fname, MPI.MODE_RDWR | MPI.MODE_CREATE)

--- a/scalapy/blockcyclic.py
+++ b/scalapy/blockcyclic.py
@@ -247,8 +247,8 @@ def localize_indices(global_indices, B, P):
     assert B > 0
     assert P > 0
 
-    t = np.divide(global_indices, B)
-    u = np.divide(t, P)
+    t = global_indices // B
+    u = t // P
     return (t - u * P, global_indices + B * (u - t))
 
 

--- a/scalapy/core.py
+++ b/scalapy/core.py
@@ -32,7 +32,7 @@ Classes
     ScalapackException
 
 """
-from __future__ import absolute_import
+from __future__ import print_function, division, absolute_import
 
 from numbers import Number
 import numpy as np
@@ -369,9 +369,9 @@ class DistributedMatrix(object):
     def local_shape(self):
         """The shape of the local matrix."""
 
-        lshape = map(blockcyclic.numrc, self.global_shape,
-                     self.block_shape, self.context.grid_position,
-                     self.context.grid_shape)
+        lshape = tuple(map(blockcyclic.numrc, self.global_shape,
+                       self.block_shape, self.context.grid_position,
+                       self.context.grid_shape))
 
         return tuple(lshape)
 
@@ -611,11 +611,11 @@ class DistributedMatrix(object):
             dm.local_array[:] = rows + cols
         """
 
-        ri, ci = map(blockcyclic.indices_rc,
-                     self.global_shape,
-                     self.block_shape,
-                     self.context.grid_position,
-                     self.context.grid_shape)
+        ri, ci = tuple(map(blockcyclic.indices_rc,
+                       self.global_shape,
+                       self.block_shape,
+                       self.context.grid_position,
+                       self.context.grid_shape))
 
         ri = ri.reshape((-1, 1), order='F')
         ci = ci.reshape((1, -1), order='F')
@@ -650,11 +650,11 @@ class DistributedMatrix(object):
             #
             raise RuntimeError('scalapy.core.DistributedMatrix.local_diagonal_indices() called on non-square matrix, and allow_non_square=False')
 
-        ri, ci = map(blockcyclic.indices_rc,
-                     self.global_shape,
-                     self.block_shape,
-                     self.context.grid_position,
-                     self.context.grid_shape)
+        ri, ci = tuple(map(blockcyclic.indices_rc,
+                       self.global_shape,
+                       self.block_shape,
+                       self.context.grid_position,
+                       self.context.grid_shape))
 
         global_index = np.intersect1d(ri, ci)
 

--- a/scalapy/core.py
+++ b/scalapy/core.py
@@ -32,15 +32,16 @@ Classes
     ScalapackException
 
 """
+from __future__ import absolute_import
 
 from numbers import Number
 import numpy as np
 
 from mpi4py import MPI
 
-import blockcyclic
-import blacs
-import mpi3util
+from . import blockcyclic
+from . import blacs
+from . import mpi3util
 
 
 class ScalapyException(Exception):

--- a/scalapy/core.py
+++ b/scalapy/core.py
@@ -388,7 +388,7 @@ class DistributedMatrix(object):
         """
 
         ## Check and set data type
-        if dtype not in typemap.keys():
+        if dtype not in list(typemap.keys()):
             raise Exception("Requested dtype not supported by Scalapack.")
 
         self._dtype = dtype
@@ -445,7 +445,6 @@ class DistributedMatrix(object):
         self._desc[7] = 0
         self._desc[8] = self.local_shape[0]
 
-
     def _mk_mpi_dtype(self):
         ## Construct the MPI datatypes (both Fortran and C ordered)
         ##   These are required for reading in and out of arrays and files.
@@ -476,10 +475,10 @@ class DistributedMatrix(object):
 
             # Create list of types for all ranks (useful for passing to global array)
             self._darr_list = [ self.mpi_dtype.Create_darray(size, ri,
-                                    self.global_shape,
-                                    [MPI.DISTRIBUTE_CYCLIC, MPI.DISTRIBUTE_CYCLIC],
-                                    self.block_shape, self.context.grid_shape,
-                                    MPI.ORDER_F).Commit() for ri in range(size) ]
+                                self.global_shape,
+                                [MPI.DISTRIBUTE_CYCLIC, MPI.DISTRIBUTE_CYCLIC],
+                                self.block_shape, self.context.grid_shape,
+                                MPI.ORDER_F).Commit() for ri in range(size) ]
 
 
     @classmethod
@@ -536,14 +535,14 @@ class DistributedMatrix(object):
            The process context. If not set uses the default (recommended).
         """
 
-        ret = cls(global_shape = (n,n),
-                  dtype = dtype,
-                  block_shape = block_shape,
-                  context = context)
+        ret = cls(global_shape=(n, n),
+                  dtype=dtype,
+                  block_shape=block_shape,
+                  context=context)
 
-        (g,r,c) = ret.local_diagonal_indices()
+        g, r, c = ret.local_diagonal_indices()
 
-        ret.local_array[r,c] = 1.0
+        ret.local_array[r, c] = 1.0
         return ret
 
 
@@ -1006,11 +1005,11 @@ class DistributedMatrix(object):
             items = tuple([slice(None, None, None) if items is Ellipsis else item for item in items])
 
         # First case deal with just a single slice (either an int or slice object)
-        if type(items) in [int, long]:
+        if isinstance(items, int):
             m, rows = regularize_idx(items, nrow, 0)
             n = ncol  # number of columns
             cols = [(0, ncol)]
-        elif type(items) is slice:
+        elif isinstance(items, slice):
             if items == slice(None, None, None):
                 return self.copy()
 
@@ -1019,35 +1018,35 @@ class DistributedMatrix(object):
             cols = [(0, ncol)]
 
         # Then deal with the case of a tuple (i.e. slicing both dimensions)
-        elif type(items) is tuple:
+        elif isinstance(items, tuple):
 
             # Check we have two indexed dimensions
             if len(items) != 2:
                 raise ValueError('Two many indices for 2D matrix: %s' % repr(items))
 
             # Check the types in the slicing are correct
-            if not ((type(items[0]) in [int, long, slice] or items[0] is Ellipsis) and
-                    (type(items[1]) in [int, long, slice] or items[1] is Ellipsis)):
+            if not ((isinstance(items[0], (int, slice)) or items[0] is Ellipsis) and
+                    (isinstance(items[1], (int, slice)) or items[1] is Ellipsis)):
                 raise ValueError('Invalid indices %s' % items)
 
             # Process case of wanting a specific row
-            if type(items[0]) in [int, long]:
+            if isinstance(items[0], int):
                 m, rows = regularize_idx(items[0], nrow, 0)
 
-                if type(items[1]) in [int, long]:
+                if isinstance(items[1], int):
                     n, cols = regularize_idx(items[1], ncol, 1)
-                elif type(items[1]) is slice:
+                elif isinstance(items[1], slice):
                     n, cols = regularize_slice(items[1], ncol)
                 else:
                     raise ValueError('Invalid indices %s' % items)
 
             # Case of wanting a slice of rows
-            elif type(items[0]) is slice:
+            elif isinstance(items[0], slice):
                 m, rows = regularize_slice(items[0], nrow)
 
-                if type(items[1]) in [int, long]:
+                if isinstance(items[1], int):
                     n, cols = regularize_idx(items[1], ncol, 1)
-                elif type(items[1]) is slice:
+                elif isinstance(items[1], slice):
                     if items[0] == slice(None, None, None) and items[1] == slice(None, None, None):
                         return self.copy()
 

--- a/scalapy/lowlevel/__init__.py
+++ b/scalapy/lowlevel/__init__.py
@@ -128,7 +128,7 @@ Scalapack Routines
 <_insert_scalapack>
 
 """
-
+from __future__ import print_function, division
 
 import numpy as np
 
@@ -140,10 +140,8 @@ from . import redist as _redist
 expand_args = True
 
 
-
-
 def _expand_work(args, query=True):
-    ## Go through an argument list and expand and WorkArrays found.
+    # Go through an argument list and expand and WorkArrays found.
 
     exp_args = []
     for arg in args:
@@ -154,7 +152,7 @@ def _expand_work(args, query=True):
 
 
 def _expand_dm(args):
-    ## Iterate through and expand any DistributedMatrices found.
+    # Iterate through and expand any DistributedMatrices found.
 
     exp_args = []
     for arg in args:
@@ -165,7 +163,7 @@ def _expand_dm(args):
 
 
 def _call_routine(routine, *args):
-    ## Call the routine, expanding any arguments as required.
+    # Call the routine, expanding any arguments as required.
 
     # Check to see if there any WorkArrays
     need_workquery = any([isinstance(arg, WorkArray) for arg in args])
@@ -186,8 +184,8 @@ def _call_routine(routine, *args):
 
 
 def _wrap_routine(rname, robj):
-    ## Generate a wrapper around the lowlevel routine which can expand the
-    ## arguments if required.
+    # Generate a wrapper around the lowlevel routine which can expand the
+    # arguments if required.
 
     # Create wrapper
     def wrapper(*args):
@@ -274,9 +272,8 @@ class WorkArray(object):
         return work_list
 
 
-
-## Add wrapped routines to this modules dictionary.
-## Also try and insert the PBLAS and ScaLAPACK routines into the docstring.
+# Add wrapped routines to this modules dictionary.
+# Also try and insert the PBLAS and ScaLAPACK routines into the docstring.
 _mod_dict = globals()
 
 _doc_redist = ''
@@ -285,7 +282,7 @@ _doc_scl = ''
 
 
 # From REDIST
-for rname, robj in _redist.__dict__.iteritems():
+for rname, robj in _redist.__dict__.items():
     if type(robj).__name__ == 'fortran':
         _mod_dict[rname] = _wrap_routine(rname, robj)
         _doc_redist += '    ' + rname + '\n'
@@ -294,7 +291,7 @@ _mod_dict['__doc__'] = _mod_dict['__doc__'].replace('<insert_redist>', _doc_redi
 
 
 # From PBLAS
-for rname, robj in _pblas.__dict__.iteritems():
+for rname, robj in _pblas.__dict__.items():
     if type(robj).__name__ == 'fortran':
         _mod_dict[rname] = _wrap_routine(rname, robj)
         _doc_pblas += '    ' + rname + '\n'
@@ -302,10 +299,9 @@ for rname, robj in _pblas.__dict__.iteritems():
 _mod_dict['__doc__'] = _mod_dict['__doc__'].replace('<insert_pblas>', _doc_pblas)
 
 # From Scalapack
-for rname, robj in _scl.__dict__.iteritems():
+for rname, robj in _scl.__dict__.items():
     if type(robj).__name__ == 'fortran':
         _mod_dict[rname] = _wrap_routine(rname, robj)
         _doc_scl += '    ' + rname + '\n'
 
 _mod_dict['__doc__'] = _mod_dict['__doc__'].replace('<insert_scalapack>', _doc_scl)
-

--- a/scalapy/lowlevel/makepyf.py
+++ b/scalapy/lowlevel/makepyf.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-from __future__ import absolute_import
+# Script for generating the F2PY interface files (pyf files) from a copy of the
+# ScaLAPACK source.
+
+from __future__ import print_function, division
+
 import os
 import shutil
 import glob

--- a/scalapy/lowlevel/makepyf.py
+++ b/scalapy/lowlevel/makepyf.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import shutil
 import glob
@@ -7,7 +9,7 @@ import subprocess
 
 from termcolor import colored
 
-import scalapack2pyf as s2p
+from . import scalapack2pyf as s2p
 
 # Script for generating pyf file.
 
@@ -33,7 +35,7 @@ os.makedirs(PBLAS_OUTDIR)
 # Files in PBLAS to process
 pblas_files = glob.glob(PBLAS_SRCDIR + '/*_.c')
 
-print "Scanning PBLAS - processing %i files" % len(pblas_files)
+print("Scanning PBLAS - processing %i files" % len(pblas_files))
 
 # Iterate over files in PBLAS and create a pyf signature file.
 for pbfile in pblas_files:
@@ -43,14 +45,14 @@ for pbfile in pblas_files:
     try:
         s2p.scalapack2pyf(pbfile, outfile)
     except s2p.ParseException as p:
-        print colored('FAILURE', 'red') + ': processing %s' % basefile
+        print(colored('FAILURE', 'red') + ': processing %s' % basefile)
 
 # Construct list of signature files that are not blacklisted.
 pblas_sigfiles = []
 for sigfile in glob.glob(PBLAS_OUTDIR + '/*.pyf'):
     fname = os.path.splitext(os.path.basename(sigfile))[0]
     if fname in blacklist:
-        print "Not processing blacklisted: %s" % fname
+        print("Not processing blacklisted: %s" % fname)
         continue
 
     pblas_sigfiles.append(sigfile)
@@ -59,8 +61,8 @@ for sigfile in glob.glob(PBLAS_OUTDIR + '/*.pyf'):
 try:
     output = subprocess.check_output([F2PY, '-h', 'pblas.pyf'] + pblas_sigfiles + ['-m', 'pblas', '--overwrite-signature'], stderr=subprocess.STDOUT)
 except Exception as e:
-    print colored('ERROR')
-    print e.output
+    print(colored('ERROR'))
+    print(e.output)
 
 
 
@@ -71,7 +73,7 @@ os.makedirs(SCL_OUTDIR)
 # Files in Scalapack to process
 scl_files = glob.glob(SCL_SRCDIR + '/*.f')
 
-print "Scanning Scalapack - processing %i files" % len(scl_files)
+print("Scanning Scalapack - processing %i files" % len(scl_files))
 
 # Iterate over files in Scalapack and create a pyf signature file.
 for pbfile in scl_files:
@@ -81,14 +83,14 @@ for pbfile in scl_files:
     try:
         s2p.scalapack2pyf(pbfile, outfile)
     except s2p.ParseException as p:
-        print colored('FAILURE', 'red') + ': processing %s' % basefile
+        print(colored('FAILURE', 'red') + ': processing %s' % basefile)
 
 # Construct list of signature files that are not blacklisted.
 scl_sigfiles = []
 for sigfile in glob.glob(SCL_OUTDIR + '/*.pyf'):
     fname = os.path.splitext(os.path.basename(sigfile))[0]
     if fname in blacklist:
-        print "Not processing blacklisted: %s" % fname
+        print("Not processing blacklisted: %s" % fname)
         continue
 
     scl_sigfiles.append(sigfile)
@@ -97,5 +99,5 @@ for sigfile in glob.glob(SCL_OUTDIR + '/*.pyf'):
 try:
     output = subprocess.check_output([F2PY, '-h', 'scalapack.pyf'] + scl_sigfiles + ['-m', 'scalapack', '--overwrite-signature'], stderr=subprocess.STDOUT)
 except Exception as e:
-    print colored('ERROR')
-    print e.output
+    print(colored('ERROR'))
+    print(e.output)

--- a/scalapy/lowlevel/scalapack2pyf.py
+++ b/scalapy/lowlevel/scalapack2pyf.py
@@ -1,5 +1,7 @@
-from __future__ import print_function
+"""Routines for parsing ScaLAPACK documentation and generating a PYF file.
+"""
 
+from __future__ import print_function, division
 
 import sys
 import re
@@ -159,6 +161,3 @@ if __name__ == '__main__':
         print("Error processing %s" % inputfile)
         print("  --", e.message)
         sys.exit(1)
-
-
-    

--- a/scalapy/lowlevel/scalapack2pyf.py
+++ b/scalapy/lowlevel/scalapack2pyf.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 
 import sys
@@ -94,7 +95,7 @@ def fill_missing(args):
         if arg['type'] is None:
 
             if previous is None:
-                print args
+                print(args)
                 raise ParseException('Could not match argument')
 
             arg['type'] = previous['type']
@@ -138,7 +139,7 @@ def scalapack2pyf(inputfile, outputfile=None):
     sig_pyf = args_to_fsig(*parsed)
 
     if outputfile is None:
-        print sig_pyf
+        print(sig_pyf)
     else:
         with open(outputfile, 'w+') as f:
             f.write(sig_pyf)
@@ -155,8 +156,8 @@ if __name__ == '__main__':
     try:
         scalapack2pyf(inputfile, outputfile)
     except ParseException as e:
-        print "Error processing %s" % inputfile
-        print "  --", e.message
+        print("Error processing %s" % inputfile)
+        print("  --", e.message)
         sys.exit(1)
 
 

--- a/scalapy/npyutils.py
+++ b/scalapy/npyutils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import
 
 import numpy as np
 import numpy.lib.format as npfor
@@ -14,7 +15,7 @@ def read_header_data(fname):
     return shape, fortran_order, dtype, header_length
 
 def write_header_data(fname, header_data):
-    
+
     version = (1, 0)
     fp = open(fname, 'r+')
     fp.write(npfor.magic(*version))
@@ -22,7 +23,7 @@ def write_header_data(fname, header_data):
     write_array_header_1_0(fp, header_data)
 
 def pack_header_data(shape, fortran_order, dtype):
-    
+
     # Do very strict type checking, which is normally a not done in python.
     # We need repr() to work perfectly.
     msg = "`shape` must me a tuple of intergers."
@@ -43,17 +44,17 @@ def pack_header_data(shape, fortran_order, dtype):
 
 def get_header_length(header):
     """Gets the total length of the header given the header data.
-    
+
     Works for header data in a dictionary (as returned by `pack_header_data` or
     for data already packed into a string (as returned by `get_header_string`).
     """
-    
+
     if isinstance(header, dict):
         header = get_header_str(header)
-    return npfor.MAGIC_LEN + 2 + len(header) 
+    return npfor.MAGIC_LEN + 2 + len(header)
 
 def get_header_str(header_data):
-    
+
     header = ["{"]
     for key, value in sorted(header_data.items()):
         # Need to use repr here, since we eval these when reading
@@ -65,7 +66,7 @@ def get_header_str(header_data):
     # boundary.  Hopefully, some system, possibly memory-mapping, can take
     # advantage of our premature optimization.
     # 1 for the newline
-    current_header_len = get_header_length(header) + 1  # 1 for newline.  
+    current_header_len = get_header_length(header) + 1  # 1 for newline.
     topad = 4096 - (current_header_len % 4096)
     header = '%s%s\n' % (header, ' '*topad)
     return header
@@ -92,4 +93,3 @@ def write_array_header_1_0(fp, d):
     header_len_str = struct.pack('<H', len(header))
     fp.write(header_len_str)
     fp.write(header)
-

--- a/scalapy/routines.py
+++ b/scalapy/routines.py
@@ -18,6 +18,7 @@ Routines
     dot
 
 """
+from __future__ import print_function, division
 
 import numpy as np
 
@@ -179,13 +180,13 @@ def eigh(A, B=None, lower=True, eigvals_only=False, overwrite_a=True, overwrite_
         if info > 0:
             if np.mod(info, 2) != 0:
                 raise core.ScalapackException("One or more eigenvectors failed to converge")
-            elif np.mod(info / 2, 2) != 0:
+            elif np.mod(info // 2, 2) != 0:
                 raise core.ScalapackException("Eigenvectors corresponding to one or more clusters of eigenvalues could not be reorthogonalized because of insufficient workspace")
-            elif np.mod(info / 4, 2) != 0:
+            elif np.mod(info // 4, 2) != 0:
                 raise core.ScalapackException("Space limit prevented p?sygvx from computing all of the eigenvectors between %f and %f. The number of eigenvectors computed is %d" % (vl, vu, nz))
-            elif np.mod(info / 8, 2) != 0:
+            elif np.mod(info // 8, 2) != 0:
                 raise core.ScalapackException("p?stebz failed to compute eigenvalues")
-            elif np.mod(info / 16, 2) != 0:
+            elif np.mod(info // 16, 2) != 0:
                 raise core.ScalapackException("The smallest minor order %d of `B` is not positive definite" % ifail[0])
             else:
                 raise core.ScalapackException("Unknown error")

--- a/scalapy/util.py
+++ b/scalapy/util.py
@@ -12,6 +12,7 @@ Routines
 
     flatten
 """
+from __future__ import print_function, division
 
 import numpy as np
 
@@ -45,7 +46,6 @@ def flatten(x):
     result = []
     for el in x:
         if isinstance(el, (list, tuple)):
-        #if hasattr(el, "__iter__") and not isinstance(el, basestring):
             result.extend(flatten(el))
         else:
             result.append(el)
@@ -64,7 +64,7 @@ def assert_square(A):
 
 
 def real_equiv(dtype):
-    ## Return the real datatype with the same precision as dtype.
+    # Return the real datatype with the same precision as dtype.
     if dtype == np.float32 or dtype == np.complex64:
         return np.float32
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ import mpi4py
 
 
 def runcommand(cmd):
-    process = subprocess.Popen(cmd.split(), shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    process = subprocess.Popen(cmd.split(), shell=False, stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT, universal_newlines=True)
     c = process.communicate()
 
     if process.returncode != 0:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 from setuptools import find_packages
 from numpy.distutils.core import setup, Extension
@@ -114,18 +115,18 @@ def cython_file(filename):
 
 omp_args = ['-fopenmp'] if use_omp else []
 
-print "============================================================================="
-print "Building Scalapy...."
-print
-print "  ScaLAPACK: %s" % scalapackversion
-print "  MPI: %s" % mpiversion
-print "  OpenMP: %s" % repr(use_omp)
-print
-print "  Compile args: %s" % repr(mpicompileargs)
-print "  Libraries: %s" % repr(scl_lib + mpilinkargs)
-print "  Library path: %s" % repr(scl_libdir)
-print
-print "============================================================================="
+print("=============================================================================")
+print("Building Scalapy....")
+print()
+print("  ScaLAPACK: %s" % scalapackversion)
+print("  MPI: %s" % mpiversion)
+print("  OpenMP: %s" % repr(use_omp))
+print()
+print("  Compile args: %s" % repr(mpicompileargs))
+print("  Libraries: %s" % repr(scl_lib + mpilinkargs))
+print("  Library path: %s" % repr(scl_libdir))
+print()
+print("=============================================================================")
 
 ## Setup the extensions we are going to build
 mpi3_ext = Extension('scalapy.mpi3util', [cython_file('scalapy/mpi3util')],

--- a/tests/test_cholesky.py
+++ b/tests/test_cholesky.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import scipy.linalg as la
 
@@ -37,8 +38,8 @@ def test_cholesky_D():
     if rank == 0:
         gUn = la.cholesky(gA)
 
-        print gUn
-        print gUd
+        print(gUn)
+        print(gUd)
         assert allclose(gUn, gUd)
 
 

--- a/tests/test_core_io.py
+++ b/tests/test_core_io.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 
 from mpi4py import MPI
@@ -37,8 +38,8 @@ def test_basic_io():
 
     if rank == 0:
         farr2 = np.fromfile(fname2, dtype=np.float64)
-        print farr2
-        print farr
+        print(farr2)
+        print(farr)
         assert (farr == farr2).all()
 
 


### PR DESCRIPTION
This should be a reasonably clean port of `scalapy` to support Python 3. Though it was done with the aid of `python-future`, it doesn't actually require any additional dependencies.

This should fix #21 